### PR TITLE
Hong/feature/ngrok

### DIFF
--- a/gatherRoom/src/main/java/com/gatherRoom/gatherRoom/config/oauth2/SecurityConfig.java
+++ b/gatherRoom/src/main/java/com/gatherRoom/gatherRoom/config/oauth2/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter  {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**", "/profile").permitAll()
+                .antMatchers("/**").permitAll()
                 .antMatchers("/api/v1/**").hasRole(Role.USER.name())
                 .anyRequest().authenticated()
                 .and()

--- a/gatherRoom/src/main/resources/templates/index.html
+++ b/gatherRoom/src/main/resources/templates/index.html
@@ -50,6 +50,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/game">Game</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/chat">소통해요</a>
+                </li>
                 <!--                 <li class="nav-item only-desktop">-->
                 <!--                    <a class="nav-link" id="side-nav-open" href="#">-->
                 <!--                        <span class="lnr lnr-menu"></span>-->

--- a/gatherRoom/src/main/resources/templates/index.html
+++ b/gatherRoom/src/main/resources/templates/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 <head>
     <!--
      - Roxy: Bootstrap template by GettTemplates.com


### PR DESCRIPTION
- active/passive mixed content 중 active mixed content error 를 Content-Security-Policy" content="upgrade-insecure-requests
라는 코드를 이용해서 해결하였다. 네트워크 요청을 보내기 전 보증되지 않은 url을 업그레이드 하도록 브라우저에 지시하는 코드이다.
